### PR TITLE
Adds ability to close conversations by swiping left

### DIFF
--- a/components/conversations/ConversationItem.tsx
+++ b/components/conversations/ConversationItem.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
-import {
-  Image,
-  Text,
-  TouchableOpacity,
-  TouchableHighlight,
-  View,
-} from 'react-native';
-import tailwind from 'tailwind-rn';
+import {Image, Text, TouchableHighlight, View} from 'react-native';
+import tailwind, {getColor} from 'tailwind-rn';
 
 import {getColorByUuid} from '../../utils';
 import {formatLastSentAt} from './support';
@@ -33,7 +27,10 @@ export default function ConversationItem({item, onSelectConversation}: Props) {
   const color = getColorByUuid(customerId);
 
   return (
-    <TouchableHighlight onPress={() => onSelectConversation(item)}>
+    <TouchableHighlight
+      underlayColor={getColor('gray-300')}
+      onPress={() => onSelectConversation(item)}
+    >
       <View
         style={tailwind(
           'flex-row p-3 border-b border-gray-100 items-center bg-white'

--- a/components/conversations/ConversationItem.tsx
+++ b/components/conversations/ConversationItem.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {Image, Text, TouchableOpacity, View} from 'react-native';
+import {
+  Image,
+  Text,
+  TouchableOpacity,
+  TouchableHighlight,
+  View,
+} from 'react-native';
 import tailwind from 'tailwind-rn';
 
 import {getColorByUuid} from '../../utils';
@@ -27,12 +33,11 @@ export default function ConversationItem({item, onSelectConversation}: Props) {
   const color = getColorByUuid(customerId);
 
   return (
-    <TouchableOpacity
-      activeOpacity={0.5}
-      onPress={() => onSelectConversation(item)}
-    >
+    <TouchableHighlight onPress={() => onSelectConversation(item)}>
       <View
-        style={tailwind('flex-row p-3 border-b border-gray-100 items-center')}
+        style={tailwind(
+          'flex-row p-3 border-b border-gray-100 items-center bg-white'
+        )}
       >
         {avatarUrl ? (
           <Image
@@ -69,6 +74,6 @@ export default function ConversationItem({item, onSelectConversation}: Props) {
           </Text>
         </View>
       </View>
-    </TouchableOpacity>
+    </TouchableHighlight>
   );
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
+    "react-native-swipe-list-view": "^3.2.9",
     "react-native-web": "~0.13.12",
     "superagent": "^6.1.0",
     "tailwind-rn": "^3.0.1"

--- a/screens/ConversationsScreen.tsx
+++ b/screens/ConversationsScreen.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import {StackScreenProps} from '@react-navigation/stack';
 import {
-  FlatList,
   Text,
   SafeAreaView,
   View,
   ActivityIndicator,
+  TouchableOpacity,
 } from 'react-native';
+import {SwipeListView} from 'react-native-swipe-list-view';
 import tailwind from 'tailwind-rn';
 
 import {RootStackParamList} from '../types';
@@ -18,6 +19,7 @@ type Props = StackScreenProps<RootStackParamList, 'Root'> & {};
 
 export default function ConversationsScreen({navigation}: Props) {
   const [isRefreshing, setRefreshing] = React.useState(false);
+  const [openRows, setOpenRows] = React.useState<{[key: string]: boolean}>({});
   const {
     fetchConversations,
     pagination,
@@ -56,6 +58,22 @@ export default function ConversationsScreen({navigation}: Props) {
     );
   };
 
+  const renderHiddenItem = ({item}: any) => {
+    return (
+      <View style={tailwind('h-full')}>
+        <TouchableOpacity
+          activeOpacity={0.5}
+          onPress={() => console.log('Tapped on', item)}
+          style={tailwind(
+            'h-full bg-gray-200 self-end justify-center items-center px-5'
+          )}
+        >
+          <Text>Close</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
   const displayed = conversations.filter((c) => c.status === 'open');
 
   return (
@@ -64,12 +82,15 @@ export default function ConversationsScreen({navigation}: Props) {
         <Text style={tailwind('font-bold text-lg')}>Conversations</Text>
       </View>
 
-      <FlatList
+      <SwipeListView
+        useFlatList={true}
         refreshing={isRefreshing}
         onRefresh={handleRefreshConversations}
         keyboardShouldPersistTaps="handled"
         data={displayed}
         renderItem={renderItem}
+        renderHiddenItem={renderHiddenItem}
+        rightOpenValue={-75}
         onEndReached={handleLoadMoreConversations}
         onEndReachedThreshold={0.01}
         onMomentumScrollBegin={(...args) => {

--- a/screens/ConversationsScreen.tsx
+++ b/screens/ConversationsScreen.tsx
@@ -19,7 +19,6 @@ type Props = StackScreenProps<RootStackParamList, 'Root'> & {};
 
 export default function ConversationsScreen({navigation}: Props) {
   const [isRefreshing, setRefreshing] = React.useState(false);
-  const [openRows, setOpenRows] = React.useState<{[key: string]: boolean}>({});
   const {
     fetchConversations,
     pagination,

--- a/screens/ConversationsScreen.tsx
+++ b/screens/ConversationsScreen.tsx
@@ -8,12 +8,14 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import {SwipeListView} from 'react-native-swipe-list-view';
+import {Icon} from 'react-native-elements/dist/icons/Icon';
 import tailwind from 'tailwind-rn';
 
 import {RootStackParamList} from '../types';
 import ConversationItem from '../components/conversations/ConversationItem';
 import {useConversations} from '../components/conversations/ConversationsProvider';
 import {sleep} from '../utils';
+import {updateConversation} from '../api';
 
 type Props = StackScreenProps<RootStackParamList, 'Root'> & {};
 
@@ -40,6 +42,17 @@ export default function ConversationsScreen({navigation}: Props) {
     setRefreshing(false);
   };
 
+  const handleCloseConversation = async (item: any) => {
+    try {
+      const {id: conversationId} = item;
+      await updateConversation(conversationId, {
+        conversation: {status: 'closed'},
+      });
+    } catch (error) {
+      console.error('Failed to close conversation', error);
+    }
+  };
+
   const handleLoadMoreConversations = async () => {
     console.log('Loading more conversations:', pagination);
 
@@ -62,12 +75,12 @@ export default function ConversationsScreen({navigation}: Props) {
       <View style={tailwind('h-full')}>
         <TouchableOpacity
           activeOpacity={0.5}
-          onPress={() => console.log('Tapped on', item)}
+          onPress={() => handleCloseConversation(item)}
           style={tailwind(
-            'h-full bg-gray-200 self-end justify-center items-center px-5'
+            'h-full bg-green-400 self-end justify-center items-center px-5'
           )}
         >
-          <Text>Close</Text>
+          <Icon name="check" type="feather" color="white" />
         </TouchableOpacity>
       </View>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7406,6 +7406,11 @@ react-native-size-matters@^0.3.1:
   resolved "https://registry.yarnpkg.com/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz#24d0cfc335a2c730f6d58bd7b43ea5a41be4b49f"
   integrity sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==
 
+react-native-swipe-list-view@^3.2.9:
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/react-native-swipe-list-view/-/react-native-swipe-list-view-3.2.9.tgz#d725c7cdf481dd5df12a00dbfe0120013b5f2e59"
+  integrity sha512-SjAEuHc/D6ovp+RjDUhfNmw6NYOntdT7+GFhfMGfP/BSLMuMWynpzJy9GKQeyB8sI78T6Lzip21TVbongOg1Mw==
+
 react-native-web@~0.13.12:
   version "0.13.18"
   resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.13.18.tgz#964f058a16521a3b9a31b091415edfef5b6ef305"


### PR DESCRIPTION
### Description

Currently, there isn't a way to close conversations. This commit adds the ability to close them by swiping left. 

**Other changes**
* Change `TouchableOpacity` to `TouchableHighlight` in `ConversationItem`. The opacity didn't work well for us if we wanted swiping behavior because the swiping UI is underneath the `ConversationItem` and is revealed when swiping.

### Screenshots

https://user-images.githubusercontent.com/1361509/129118925-135529ae-c58a-4023-a608-cb760474ed0c.mp4
